### PR TITLE
fix: remove 'i' e 'u' da lista de palavras a não serem capitalizadas

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -72,6 +72,12 @@ describe('With prepositions', () => {
     const after = 'Aracaju em Boas Mãos'
     expect(capitalize(before)).toEqual(after)
   })
+
+  it('capitalize("D. PEDRO I") should return "D. Pedro I"', () => {
+    const before = 'D. PEDRO I'
+    const after = 'D. Pedro I'
+    expect(capitalize(before)).toEqual(after)
+  })
 })
 
 describe('With initials', () => {

--- a/src/keep-lowercase.js
+++ b/src/keep-lowercase.js
@@ -10,7 +10,6 @@ const keepLowercase = [
   'dos',
   'e',
   'em',
-  'i',
   'na',
   'nas',
   'no',
@@ -18,7 +17,6 @@ const keepLowercase = [
   'o',
   'por',
   'sem',
-  'u',
 ]
 
 export default keepLowercase


### PR DESCRIPTION
Como descrito por @marcospcury na Issue #14:

> Os caracteres 'i' e 'u' nao devem ser desconsiderados da capitalizacao pois nao sao preposicoes, o que impacta a capitalizacao de numerais romanos, por exemplo

Obs.: Esta PR, porém, não soluciona a capitalização de algarismos romanos. Por exemplo, `D. PEDRO I` passa a ser `D. Pedro I`, porém, `D. PEDRO II` continuará resultando em `D. Pedro Ii`. Podemos abrir uma nova issue/PR pra tratar disso, caso surja necessidade. A solução para todos os algarismos romanos não é tão trivial.