### PR TITLE
Adicionar siglas de tipos de empresa ao keepUppercase

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -92,4 +92,16 @@ describe('With initials', () => {
     const after = 'CNPJ da Empresa X'
     expect(capitalize(before)).toEqual(after)
   })
+
+  it('capitalize("EMPRESA LTDA ME") should return "Empresa LTDA ME"', () => {
+    const before = 'EMPRESA LTDA ME'
+    const after = 'Empresa LTDA ME'
+    expect(capitalize(before)).toEqual(after)
+  })
+
+  it('capitalize("SANTANDER SA") should return "Santander SA"', () => {
+    const before = 'SANTANDER SA'
+    const after = 'Santander SA'
+    expect(capitalize(before)).toEqual(after)
+  })
 })

--- a/src/keep-uppercase.js
+++ b/src/keep-uppercase.js
@@ -6,6 +6,12 @@ const keepUppercase = [
   'ltda',
   'qp',
   'tv',
+  'mei', 
+  'me', 
+  'ei',
+  'epp',
+  'eireli', 
+  'sa'
 ]
 
 export default keepUppercase


### PR DESCRIPTION
Adicionar as seguintes siglas ([tipos de empresa](https://www.treasy.com.br/blog/diferencas-entre-mei-me-ei-epp-eireli-sa-ltda/)) ao keepUppercase: `MEI, ME, EI, EPP, EIRELI, SA`. Adicionar testes relacionados às novas siglas. 